### PR TITLE
fix for GrovePi library compile fail

### DIFF
--- a/scripts/deployPiDependencies.sh
+++ b/scripts/deployPiDependencies.sh
@@ -1,7 +1,11 @@
+rm -rf IoTDevices
 git clone https://github.com/emoranchel/IoTDevices.git --depth 1
 cd IoTDevices
 
 mvn -q install:install-file -Dfile=lib/dio.jar -DgroupId=jdk.dio -DartifactId=dio -Dversion=1.0 -Dpackaging=jar
+
+mvn -q clean install -f GrovePi-spec/pom.xml
+mvn -q clean install -f Pi-spec/pom.xml
 
 mvn -f GrovePi-spec/pom.xml build-helper:parse-version versions:set -DnewVersion="\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.incrementalVersion}"
 mvn -f GrovePi-spec/pom.xml versions:update-properties -Dincludes="org.iot.raspberry" -DallowSnapshots=false
@@ -37,14 +41,13 @@ mvn -f examples/pom.xml build-helper:parse-version versions:set -DnewVersion="\$
 mvn -f examples/pom.xml versions:update-properties -Dincludes="org.iot.raspberry" -DallowSnapshots=false
 mvn -f examples/pom.xml versions:use-releases -Dincludes=org.iot.raspberry
 
-mvn -q clean install -f GrovePi-spec/pom.xml
-mvn -q clean install -f Pi-spec/pom.xml
-mvn -q clean install -f GrovePi-pi4j/pom.xml
-mvn -q clean install -f GrovePi-dio/pom.xml
-mvn -q clean install -f Pi-dio/pom.xml
-mvn -q clean install -f Pi-pi4j/pom.xml
+mvn -q clean source:jar install -f GrovePi-spec/pom.xml
+mvn -q clean source:jar install -f Pi-spec/pom.xml
+mvn -q clean source:jar install -f GrovePi-pi4j/pom.xml
+mvn -q clean source:jar install -f GrovePi-dio/pom.xml
+mvn -q clean source:jar install -f Pi-dio/pom.xml
+mvn -q clean source:jar install -f Pi-pi4j/pom.xml
 
-ls ~/.m2/repository/org/iot/raspberry
+find  ~/.m2/repository/org/iot/raspberry -name "*.jar"
 cd ..
 
-rm -rf IoTDevices


### PR DESCRIPTION
problem is in ./scripts/deployPiDependencies.sh
to reproduce
rm -rf  ~/.m2/repository/org/iot/raspberry/
and run   ./scripts/quickstart.sh -cc -i somethingunique

signature is:
CURRENT_DIR : /predix/Documents/other-projects/proj20_pi_experimental/predix-machine-template-adapter-pi/predix-scripts/bash
[ERROR] Failed to execute goal on project predix-machine-template-adapter-pi: Could not resolve dependencies for project com.ge.predix.solsvc:predix-machine-template-adapter-pi:bundle:1.1.15: The following artifacts could not be resolved: org.iot.raspberry:GrovePi-spec:jar:0.1.0, org.iot.raspberry:Pi-pi4j:jar:0.1.0, org.iot.raspberry:Pi-dio:jar:0.1.0: Could not find artifact org.iot.raspberry:GrovePi-spec:jar:0.1.0 in predix.repo (https://artifactory.predix.io/artifactory/PREDIX-EXT) -> [Help 1]

the problem is several of the GrovePi targets have dependency of GrovePi-spec and Pi-spec _SNAPSHOT version and these were not being built

also add source to local repository so it is available for Spring Tool Suite to help beginners