### PR TITLE
change pom.xml to fix libpi4j.so

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,9 @@
 				<configuration>
 					<instructions>
 						<_noee>true</_noee>
+						<Include-Resource>
+						  pi4j-core-1.1.jar
+						</Include-Resource>
 						<Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
 						<Bundle-Version>${project.version}</Bundle-Version>
 						<Bundle-Classpath>


### PR DESCRIPTION
This pull request fixes the problem as described in
[https://forum.predix.io/questions/20035/raspberry-pi-tutorial-libpi4jso-exception.html](https://forum.predix.io/questions/20035/raspberry-pi-tutorial-libpi4jso-exception.html)

A pull request is available.

The change adds an Include-Resource on the pi4j-core jarfile
```
                                <configuration>
                                        <instructions>
                                                <Include-Resource>
                                                  pi4j-core-1.1.jar
                                                </Include-Resource>
```

The signature is where Raspberry Pi throws the exception cannot find libpi4j.so

 ESC[1mESC[36m2017-03-17 09:20:11,889[Component Resolve Thread (Bundle 38)]|ESC[44mERRORESC[49m|com.pi4j.util.NativeLibraryLoader|128-com.ge.predix.solsvc.predix-machine-template-adapte
r-pi-1.1.15|ESC[21mESC[mUnable to load [libpi4j.so] using path: [/lib/raspberrypi/static/libpi4j.so]
 java.lang.SecurityException: Unable to create temporary file or directory
