### PR TITLE
fix compile GrovePi where no  ~/.m2/repository/org/iot/raspberry

### DIFF
--- a/scripts/deployPiDependencies.sh
+++ b/scripts/deployPiDependencies.sh
@@ -3,6 +3,9 @@ cd IoTDevices
 
 mvn -q install:install-file -Dfile=lib/dio.jar -DgroupId=jdk.dio -DartifactId=dio -Dversion=1.0 -Dpackaging=jar
 
+mvn -q clean install -f GrovePi-spec/pom.xml
+mvn -q clean install -f Pi-spec/pom.xml
+
 mvn -f GrovePi-spec/pom.xml build-helper:parse-version versions:set -DnewVersion="\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.incrementalVersion}"
 mvn -f GrovePi-spec/pom.xml versions:update-properties -Dincludes="org.iot.raspberry" -DallowSnapshots=false
 mvn -f GrovePi-spec/pom.xml versions:use-releases -Dincludes=org.iot.raspberry


### PR DESCRIPTION
This pull request fixes a problem seen by new users (who do not have an existing ~/.m2/repository/org/iot/raspberry)   i.e. the GrovePi library.

The change is to deployPiDependencies.sh  and adds
```
mvn -q clean install -f GrovePi-spec/pom.xml
mvn -q clean install -f Pi-spec/pom.xml
```
near the top - before the lines with parse-version and update-properties.

These are needed because the script does not othewise build artifacts as "SNAPSHOT" version.    But two of the  GrovePi entities themselves depend on the SNAPSHOT version.  Specifically   GrovePi-pi4j requires the SNAPSHOT version of GrovePi-spec   and  Pi-pi4j requires the SNAPSHOT version of Pi-spec.  

Problem Description:
For a new user (with no preexisting ~/.m2/repository/org/iot/raspberry) the raspberry pi tutorial does not compile, with the message.

     [ERROR] Failed to execute goal on project GrovePi-pi4j: Could not resolve dependencies for project org.iot.raspberry:GrovePi-pi4j:jar:0.1.0: Could not find artifact org.iot.raspberry:Gr
     ovePi-spec:jar:0.1.0-SNAPSHOT -> [Help 1]

This can be reproduced by

     mv ~/.m2/repository/org/iot/raspberry  ~/.m2/repository/org/iot/raspberry_saved
     and then re-running the  quickstart.sh

