### PR TITLE
workaround for i2c exception - add retry to i2c read

### DIFF
--- a/src/main/java/com/ge/predix/solsvc/workshop/adapter/RaspberryPISubscriptionAdapter.java
+++ b/src/main/java/com/ge/predix/solsvc/workshop/adapter/RaspberryPISubscriptionAdapter.java
@@ -299,8 +299,9 @@ public class RaspberryPISubscriptionAdapter
         DecimalFormat df = new DecimalFormat("####.##"); //$NON-NLS-1$
         double fvalue = 0.0f;
         WorkshopDataNodePI node = this.dataNodes.get(nodeId);
-    	try {
-			switch (node.getNodeType()) {
+		for (int try_num = 1;; try_num++) {
+			try {
+				switch (node.getNodeType()) {
 				case "Light": //$NON-NLS-1$
 					fvalue = node.getLightNode().get();
 				break;
@@ -329,9 +330,17 @@ public class RaspberryPISubscriptionAdapter
 					break;
 				default:
 					break;
+				}
+			} catch (Exception e) {
+				if (try_num < 3) {
+					String msg = String.format("Exception when reading data from sensor node (will retry)\n%s", //$NON-NLS-1$
+							e.toString());
+					_logger.error(msg);
+				} else {
+					throw new RuntimeException("Exception when reading data from the sensor node", e); //$NON-NLS-1$
+				}
 			}
-		} catch (Exception e) {
-			throw new RuntimeException("Exception when reading data from the sensor nodes",e); //$NON-NLS-1$
+			break;
 		}
     	
         PEnvelope envelope = new PEnvelope(fvalue);


### PR DESCRIPTION
This pull request updates the Raspberry Pi demo to work around the I2c exception that occurs from hardware i2c clock stretching.  The update adds a retry to the i2c read in
src/main/java/com/ge/predix/solsvc/workshop/adapter/RaspberryPISubscriptionAdapter.java 
 so when the I2c read gets an exception it will be retried (up to 3 times).

The I2c clock problem was originally described in
 https://forum.predix.io/questions/19383/ioexception-error-writing-to-i2cdevice-on-i2cbus-g.html
and there is a different fix that uses the i2c-gpio overlay.  But that fix needs to be reapplied every reboot, and introducing the i2c-gpio overlay is a change that would be nice to avoid.

This workaround avoids the i2c-gpio overlay and is a persistent fix to the problem for this application.

