### PR TITLE
update GrovePi node id numbers for temperature and button sensors

### DIFF
--- a/config/com.ge.predix.workshop.nodeconfig.json
+++ b/config/com.ge.predix.workshop.nodeconfig.json
@@ -12,11 +12,11 @@
    {  
       "nodeName": "Temperature:TAE",  
       "nodeType": "Temperature",  
-      "nodePin": 3
+      "nodePin": 0
    },
    {  
       "nodeName": "Button:TAE",  
       "nodeType": "Button",  
-      "nodePin": 4
+      "nodePin": 2
    }
 ]


### PR DESCRIPTION
The "button" and "temperature/humidity" sensors are not working on the Raspberry Pi demo (predix-machine-template-adapter-pi / quickstart.sh).  Neither sensor shows any activity on the cloud web page, and the button does not sound the buzzer as it should.

The cause is the "node_id"  in   config/nodeconfig.json file  are incorrect for these devices.

Refer to    [https://www.dexterindustries.com/GrovePi/engineering/port-description/](https://www.dexterindustries.com/GrovePi/engineering/port-description/)     for description of the GrovePi+ port numbering, which is summarized below.  The Predix Demo application assigns sensors as shown in the right column as described at the bottom of [this page](https://www.predix.io/resources/tutorials/tutorial-details.html?tutorial_id=1741&tag=1750&journey=Setup%20Raspberry%20Pi%20for%20Predix&resources=1785,1741,1742,1743)



> 
Port ___ calls ___________ Node _______ Predix Demo
analog
A0 __ analogRead/Write()____ 0 ______ temp/humidity sensor
A1  __ analogRead/Write()____  1 ________ light sensor
A2  __ analogRead/Write()____ 2 ________ rotary sensor
digital
D2 __ digitalRead/Write() ____ 2 ________ button sensor
D3 __ digitalRead/Write() ____ 3 ___________ led
D4 __ digitalRead/Write() ____ 4
D5 __ digitalRead/Write() ____ 5 __________ buzzer
D6 __ digitalRead/Write() ____ 6
D7 __ digitalRead/Write() ____ 7
D8 __ digitalRead/Write() ____ 8
i2c
I2C1
I2C2
I2C3

The  change to  config/nodeconfig.json    corrects the node id used for the temperature/humidity and button sensors.   With this change the button sensor works.  The temperature/humidity sensor has additional problems not fixed here.